### PR TITLE
add pagination for viewing the calendar

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,24 +9,22 @@
 </div>
 
 <div id="scheduleTable" class="mx-3">
-    <template class="calendar_day" v-for="(day, date, dayIndex) in days">
+    <div class="calendar_day" v-for="(day, date, dayIndex) in days">
         <div class="h1 my-3">
-            <span class="badge display_date text-light">{{day.display_date}}</span>
+            <span class="badge display_date text-light">{{ getFullDisplayDate(day.date) }}</span>
         </div>
-        <div class="position-relative">
-            <div>
-                <div class="border-bottom"
-                     :style="{ width: getFullDayWidth(day.sessions.length) + 'px',
-                     height: getHalfHourHeight() + 'px' }"
-                     v-for="hour in numHalfHoursInDay(day.first_session_start_time, day.last_session_end_time)">
-                    <span class="time_label fixed_scrolling position-absolute bg-transparent font-weight-bold"
-                    :style="{ width: constantsObject.timeLabelWidth + 'px' }">
-                        {{ getDisplayHours(day.first_session_start_time, (hour-1)/2) }}
-                    </span>
-                </div>
+        <div class="position-relative d-inline-block">
+            <div class="border-bottom"
+                 :style="{ width: getFullDayWidth() + 'px',
+                 height: getHalfHourHeight() + 'px' }"
+                 v-for="hour in numHalfHoursInDay(day.first_session_start_time, day.last_session_end_time)">
+                <span class="time_label position-absolute bg-transparent font-weight-bold"
+                :style="{ width: constantsObject.timeLabelWidth + 'px' }">
+                    {{ getDisplayHours(day.first_session_start_time, (hour-1)/2) }}
+                </span>
             </div>
 
-            <template v-for="(session, index) in day.sessions">
+            <template v-for="(session, index) in day.display_sessions">
                 <div class="session_block card position-absolute mr-1" :class="getTrackClass(session)"
                      :style="{ height: getHeightForSession(session) + 'px',
                      width: constantsObject.sessionBlockWidth + 'px',
@@ -35,27 +33,41 @@
                      :title="session.title"
                      v-on:click.capture="launchModal(session)">
                     <div class="card-body p-2">
-                        <h5 class="card-title">{{session.title}}</h5>
+                        <h5 class="card-title">{{ session.title }}</h5>
                     </div>
                 </div>
             </template>
         </div>
-    </template>
+
+        <div class="d-inline-block align-top"
+             :style="{ height: getFullDayHeight(day.first_session_start_time, day.last_session_end_time) + 'px'}">
+            <div class="sticky-top">
+                <div>{{ getDayOfWeekName(day.date) }}</div>
+                <button type="button" class="btn btn-primary mt-2"
+                        v-if="day.current_page !== 0"
+                        v-on:click="getPreviousPage(date)">< Previous</button>
+                <button type="button" class="btn btn-primary mt-2"
+                        v-if="day.current_page < day.num_pages - 1"
+                        v-on:click="getNextPage(date)">Next ></button>
+            </div>
+        </div>
+
+    </div>
 </div>
 
 <div class="modal fade" id="sessionModal" tabindex="-1" role="dialog" aria-labelledby="sessionTitleLabel" aria-hidden="true">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="sessionTitleLabel">{{session.title}}</h5>
+                <h5 class="modal-title" id="sessionTitleLabel">{{ session.title }}</h5>
                 <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
             <div class="modal-body">
-                <div><span class="font-weight-bold">Track:</span> {{session.track}} | <span class="font-weight-bold">Audience Level:</span> {{session.audience_level}}</div>
-                <div class="font-weight-light font-italic">{{getDisplayTime(session.start_time)}} to {{getDisplayTime(session.end_time)}}</div>
-                <div class="mt-2">{{session.description}}</div>
+                <div><span class="font-weight-bold">Track:</span> {{ session.track }} | <span class="font-weight-bold">Audience Level:</span> {{ session.audience_level }}</div>
+                <div class="font-weight-light font-italic">{{ getDisplayTime(session.start_time) }} to {{ getDisplayTime(session.end_time) }}</div>
+                <div class="mt-2">{{ session.description }}</div>
             </div>
         </div>
     </div>
@@ -76,6 +88,10 @@
 
     .card{
         overflow: hidden;
+    }
+
+    .sticky-top {
+        top: 0.5em;
     }
 
     /* TRACKS */

--- a/tests/calendar_generator_tests.js
+++ b/tests/calendar_generator_tests.js
@@ -11,55 +11,55 @@ describe("Calendar Generator", function() {
         let days = getSessionInfoFromPage();
         const tuesdayDate = 1537880400000;
         const tuesdayObject = {
-            display_date: 'Tuesday, September 25, 2018',
+            date: 1537880400000,
             first_session_start_time: 1537907400000,
             last_session_end_time: 1537920000000
         };
 
         const wednesdayDate = 1537966800000;
         const wednesdayObject = {
-            display_date: 'Wednesday, September 26, 2018',
+            date: 1537966800000,
             first_session_start_time: 1537957800000,
             last_session_end_time: 1538004600000
         };
 
         const thursdayDate = 1538053200000;
         const thursdayObject = {
-            display_date: 'Thursday, September 27, 2018',
+            date: 1538053200000,
             first_session_start_time: 1538047800000,
             last_session_end_time: 1538083800000
         };
 
         const fridayDate = 1538139600000;
         const fridayObject = {
-            display_date: 'Friday, September 28, 2018',
+            date: 1538139600000,
             first_session_start_time: 1538139600000,
             last_session_end_time: 1538190000000
         };
 
         // Tuesday
-        expect(days[tuesdayDate].display_date).toBe(tuesdayObject.display_date);
+        expect(days[tuesdayDate].date).toBe(tuesdayObject.date);
         expect(days[tuesdayDate].first_session_start_time).toBe(tuesdayObject.first_session_start_time);
         expect(days[tuesdayDate].last_session_end_time).toBe(tuesdayObject.last_session_end_time);
-        expect(days[tuesdayDate].sessions.length).toBe(5);
+        expect(days[tuesdayDate].all_sessions.length).toBe(5);
 
         // Wednesday
-        expect(days[wednesdayDate].display_date).toBe(wednesdayObject.display_date);
+        expect(days[wednesdayDate].date).toBe(wednesdayObject.date);
         expect(days[wednesdayDate].first_session_start_time).toBe(wednesdayObject.first_session_start_time);
         expect(days[wednesdayDate].last_session_end_time).toBe(wednesdayObject.last_session_end_time);
-        expect(days[wednesdayDate].sessions.length).toBe(126);
+        expect(days[wednesdayDate].all_sessions.length).toBe(126);
 
         // Thursday
-        expect(days[thursdayDate].display_date).toBe(thursdayObject.display_date);
+        expect(days[thursdayDate].date).toBe(thursdayObject.date);
         expect(days[thursdayDate].first_session_start_time).toBe(thursdayObject.first_session_start_time);
         expect(days[thursdayDate].last_session_end_time).toBe(thursdayObject.last_session_end_time);
-        expect(days[thursdayDate].sessions.length).toBe(172);
+        expect(days[thursdayDate].all_sessions.length).toBe(172);
 
         // Friday
-        expect(days[fridayDate].display_date).toBe(fridayObject.display_date);
+        expect(days[fridayDate].date).toBe(fridayObject.date);
         expect(days[fridayDate].first_session_start_time).toBe(fridayObject.first_session_start_time);
         expect(days[fridayDate].last_session_end_time).toBe(fridayObject.last_session_end_time);
-        expect(days[fridayDate].sessions.length).toBe(104);
+        expect(days[fridayDate].all_sessions.length).toBe(104);
     });
 
     // Tests parseSessionInfo from various sessions
@@ -341,7 +341,7 @@ describe("Calendar Generator", function() {
 describe("Vue Instance Methods", function() {
     document.body.innerHTML = '<div id="scheduleTable"></div>';
     const constants = getConstants();
-    const VueInstance = getVueInstance({}, constants);
+    const VueInstance = getCalendarVueInstance({}, constants, {});
     const methods = VueInstance.$options.methods;
 
 
@@ -504,7 +504,7 @@ describe("Vue Instance Methods", function() {
     // Tests getTopOffsetForSession
     it('get top offset for 11:30am session on Wednesday', function() {
         const day = {
-            display_date: 'Tuesday, September 25, 2018',
+            display_date: 1537880400000,
             first_session_start_time: 1537907400000,
             last_session_end_time: 1537920000000,
         };
@@ -575,7 +575,6 @@ describe("Vue Instance Methods", function() {
         expect(methods.getLeftInsetForSession(37)).toBe(7115);
     });
 
-
     // Test getNumHalfHoursInDay
     it('correctly calculate number of half hours in a day that starts on a half hour and ends on an hour', function() {
         expect(methods.numHalfHoursInDay(1537907400000, 1537920000000)).toBe(8);
@@ -585,8 +584,17 @@ describe("Vue Instance Methods", function() {
         expect(methods.numHalfHoursInDay(1537957800000, 1538004600000)).toBe(26);
     });
 
-    // Test getDisplayHours
+
     // TODO: These tests will probably fail in other timezones
+    // Test getFullDisplayDate
+    it('correctly print out the full date', function() {
+        expect(methods.getFullDisplayDate(1537880400000)).toBe("Tuesday, September 25, 2018");
+        expect(methods.getFullDisplayDate(1537966800000)).toBe("Wednesday, September 26, 2018");
+        expect(methods.getFullDisplayDate(1538053200000)).toBe("Thursday, September 27, 2018");
+        expect(methods.getFullDisplayDate(1538139600000)).toBe("Friday, September 28, 2018");
+    });
+
+    // Test getDisplayHours
     it('correctly display first hour of the day', function() {
         expect(methods.getDisplayHours(1538139600000, 0)).toBe("9:00 AM");
     });
@@ -599,10 +607,27 @@ describe("Vue Instance Methods", function() {
         expect(methods.getDisplayHours(1538139600000, 4.5)).toBe("1:30 PM");
     });
 
+
+    // Test getDayOfWeekName
+    it('correctly print out the full date', function() {
+        expect(methods.getDayOfWeekName(1537880400000)).toBe("Tuesday");
+        expect(methods.getDayOfWeekName(1537966800000)).toBe("Wednesday");
+        expect(methods.getDayOfWeekName(1538053200000)).toBe("Thursday");
+        expect(methods.getDayOfWeekName(1538139600000)).toBe("Friday");
+    });
+
     // Test getFullDayWidth
     it('full day width is calculated correctly', function() {
-        expect(methods.getFullDayWidth(50)).toBe(9585);
-        expect(methods.getFullDayWidth(4)).toBe(845);
+        expect(methods.getFullDayWidth()).toBe(1415);
+    });
+
+    // Test getFullDayHeight
+    it('correctly calculate the height of a 4 hour day', function() {
+        expect(methods.getFullDayHeight(1537907400000, 1537920000000)).toBe(480);
+    });
+
+    it('correctly calculate the height of a 13 hour day', function() {
+        expect(methods.getFullDayHeight(1537957800000, 1538004600000)).toBe(1560);
     });
 
     // Test getHalfHourHeight

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
     // list of files / patterns to load in the browser
     files: [
         'libraries/jquery.min.js',
-        'libraries/vue.js',
+        'libraries/vue.min.js',
         'tests/helpers/mock_chrome_helper.js',
         'src/calendar_generator.js',
         'tests/helpers/schedule_dom.html',


### PR DESCRIPTION
Add pagination to the calendar view instead of infinite scrolling.  Allows users to go back and forth and stay in the same view.

![image](https://user-images.githubusercontent.com/1069030/45935515-299efa00-bf7a-11e8-9ffe-b6d0b917034f.png)
