### PR TITLE
add the ability to hide, favorite, or review a session later

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Grace Hopper 2018 Calendar View",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Make the Grace Hopper 2018 schedule easier to visualize!",
     "permissions": ["storage", "declarativeContent", "activeTab"],
     "background": {

--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,10 @@
 chrome.runtime.onInstalled.addListener(function() {
-    chrome.storage.sync.set( { showing_calendar: false }, function() {
+    chrome.storage.sync.set( {
+        showing_calendar: false,
+        hidden_sessions: [],
+        favorited_sessions: [],
+        review_later_sessions: [],
+    }, function() {
         console.log("The calendar is not displayed by default.");
     });
 

--- a/src/chrome_helper.js
+++ b/src/chrome_helper.js
@@ -1,7 +1,10 @@
 class ChromeHelper {
     static keys() {
         return {
-            showing_calendar: 'showing_calendar'
+            showing_calendar: 'showing_calendar',
+            hidden_sessions: 'hidden_sessions',
+            favorited_sessions: 'favorited_sessions',
+            review_later_sessions: 'review_later_sessions',
         };
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,8 @@
         <li>2. Any filters applied to the original schedule list will be reflected when the calendar view is shown (apply filters using Advanced Search)</li>
         <li>3. Click on a session to display a modal with more information about the session</li>
         <li>4. Sessions are color coded by track</li>
+        <li>5. To view more sessions for a day click the "next" button</li>
+        <li>6. You can now hide, favorite &#9733; or mark a session to be reviewed later &#9888; (Note: being able to see these lists or filter by choice is still a work in progress)</li>
     </ul>
 </div>
 
@@ -25,6 +27,7 @@
             </div>
 
             <template v-for="(session, index) in day.display_sessions">
+
                 <div class="session_block card position-absolute mr-1" :class="getTrackClass(session)"
                      :style="{ height: getHeightForSession(session) + 'px',
                      width: constantsObject.sessionBlockWidth + 'px',
@@ -33,7 +36,13 @@
                      :title="session.title"
                      v-on:click.capture="launchModal(session)">
                     <div class="card-body p-2">
-                        <h5 class="card-title">{{ session.title }}</h5>
+                        <h5 class="card-title">
+                            <span v-if="session.favorited"
+                                  :class="[session.track === 'Products A to Z' ? 'text-dark' : 'text-warning']">&#9733;</span>
+                            <span v-if="session.flagged_for_review"
+                                  class="font-weight-bold">&#9888;</span>
+                            {{ session.title }}
+                        </h5>
                     </div>
                 </div>
             </template>
@@ -51,23 +60,39 @@
                         v-on:click="getNextPage(date)">Next ></button>
             </div>
         </div>
-
     </div>
-</div>
 
-<div class="modal fade" id="sessionModal" tabindex="-1" role="dialog" aria-labelledby="sessionTitleLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="sessionTitleLabel">{{ session.title }}</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div><span class="font-weight-bold">Track:</span> {{ session.track }} | <span class="font-weight-bold">Audience Level:</span> {{ session.audience_level }}</div>
-                <div class="font-weight-light font-italic">{{ getDisplayTime(session.start_time) }} to {{ getDisplayTime(session.end_time) }}</div>
-                <div class="mt-2">{{ session.description }}</div>
+    <div class="modal fade" id="sessionModal" tabindex="-1" role="dialog" aria-labelledby="sessionTitleLabel" aria-hidden="true">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="sessionTitleLabel">{{selectedSession.title}}</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div><span class="font-weight-bold">Track:</span> {{selectedSession.track}} | <span class="font-weight-bold">Audience Level:</span> {{selectedSession.audience_level}}</div>
+                    <div class="font-weight-light font-italic">{{getDisplayTime(selectedSession.start_time)}} to {{getDisplayTime(selectedSession.end_time)}}</div>
+                    <div class="mt-2">{{selectedSession.description}}</div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-danger"
+                            data-dismiss="modal"
+                            v-on:click="hideSession(selectedSession)">
+                        Hide
+                    </button>
+                    <button type="button" class="btn btn-warning"
+                            data-dismiss="modal"
+                            v-on:click="reviewSessionLater(selectedSession)">
+                        Review Later
+                    </button>
+                    <button type="button" class="btn btn-success"
+                            data-dismiss="modal"
+                            v-on:click="favoriteSession(selectedSession)">
+                        Add to Favorites
+                    </button>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Adding the ability to hide a session completely, favorite it or mark it to be reviewed later.  This is saved in the chrome settings for that session so if you hide and show the calendar view again it will persist

TODO: Currently there is no way to filter by these choices or see a complete list of favorites, etc.  Also: a session may be on more than one list at this time.

![image](https://user-images.githubusercontent.com/1069030/45962117-1f1e4800-bfee-11e8-8422-aa0c85f4f649.png)

![image](https://user-images.githubusercontent.com/1069030/45962217-5987e500-bfee-11e8-9698-883692ebd1f9.png)

